### PR TITLE
set default line-length to match the black default

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,7 +12,7 @@ inputs:
   line-length:
     description: 'The number of characters allowed per line.'
     required: false
-    default: '81'
+    default: '88'
   sanity-check:
     description: 'Sanity check [fast|safe]'
     required: false


### PR DESCRIPTION
This is a quick-fix so it behaves like default black by default.

Ideally we'll later also change it to not set any value on the commandline if nothing specific is set on the github action. That way it can use the line-length setting from `pyproject.toml`, if it is defined there.