### PR TITLE
Change defaults to black defaults

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,11 +12,11 @@ inputs:
   line-length:
     description: 'The number of characters allowed per line.'
     required: false
-    default: '81'
+    default: '88'
   sanity-check:
     description: 'Sanity check [fast|safe]'
     required: false
-    default: 'fast'
+    default: 'safe'
   only-check:
     description: 'Only check the files instead of modify them [yes|no] '
     required: false


### PR DESCRIPTION
I was surprised when this didn't use the default options in Black, since it didn't match with what I was linting on my machine. I think the defaults should match, since that will eliminate a lot of confusion.

See https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html for Black recommended defaults